### PR TITLE
Fix URL encoding for search facet params

### DIFF
--- a/sites/store1/storefront/src/utils/index.ts
+++ b/sites/store1/storefront/src/utils/index.ts
@@ -65,14 +65,20 @@ export const enableDisableFacetValues = (_facedValues: FacetWithValues[], ids: s
 	return { facedValues, facetValueIds };
 };
 
-export const changeUrlParamsWithoutRefresh = (term: string, facetValueIds: string[]) => {
-	const f = facetValueIds.join('-');
-	return window.history.pushState(
-		'',
-		'',
-		`${window.location.origin}${window.location.pathname}?q=${term}${f ? `&f=${f}` : ''}`
-	);
-};
+export const changeUrlParamsWithoutRefresh = (
+        term: string,
+        facetValueIds: string[]
+) => {
+        const encodedTerm = encodeURIComponent(term);
+        const encodedFacets = facetValueIds
+                .map((f) => encodeURIComponent(f))
+                .join('-');
+        return window.history.pushState(
+                '',
+                '',
+                `${window.location.origin}${window.location.pathname}?q=${encodedTerm}${encodedFacets ? `&f=${encodedFacets}` : ''}`
+        );
+}; 
 
 export const setCookie = (name: string, value: string, days: number) => {
 	let expires = '';

--- a/sites/store1/storefront2/src/utils/index.ts
+++ b/sites/store1/storefront2/src/utils/index.ts
@@ -65,13 +65,19 @@ export const enableDisableFacetValues = (_facedValues: FacetWithValues[], ids: s
 	return { facedValues, facetValueIds };
 };
 
-export const changeUrlParamsWithoutRefresh = (term: string, facetValueIds: string[]) => {
-	const f = facetValueIds.join('-');
-	return window.history.pushState(
-		'',
-		'',
-		`${window.location.origin}${window.location.pathname}?q=${term}${f ? `&f=${f}` : ''}`
-	);
+export const changeUrlParamsWithoutRefresh = (
+        term: string,
+        facetValueIds: string[]
+) => {
+        const encodedTerm = encodeURIComponent(term);
+        const encodedFacets = facetValueIds
+                .map((f) => encodeURIComponent(f))
+                .join('-');
+        return window.history.pushState(
+                '',
+                '',
+                `${window.location.origin}${window.location.pathname}?q=${encodedTerm}${encodedFacets ? `&f=${encodedFacets}` : ''}`
+        );
 };
 
 export const setCookie = (name: string, value: string, days: number) => {


### PR DESCRIPTION
## Summary
- encode search term and facet IDs when modifying URL

## Testing
- `npx tsc -p tsconfig.json` in `sites/store1/storefront`
- `npm run lint` in `sites/store1/storefront`
- `npx tsc -p tsconfig.json` in `sites/store1/storefront2`
- `npm run lint` in `sites/store1/storefront2`


------
https://chatgpt.com/codex/tasks/task_e_6848962ee6ac8325a06a625e09032d77