### PR TITLE
Add Playwright checkout test

### DIFF
--- a/sites/store1/storefront/package.json
+++ b/sites/store1/storefront/package.json
@@ -33,7 +33,8 @@
     "prepare": "husky install",
     "preview": "qwik build preview && vite preview --open",
     "start": "pnpm generate && vite --open --mode ssr",
-    "qwik": "qwik"
+    "qwik": "qwik",
+    "test": "playwright test"
   },
   "devDependencies": {
     "@angular/compiler": "^17.1.3",
@@ -68,7 +69,8 @@
     "undici": "^6.21.3",
     "vite": "^5.4.19",
     "vite-tsconfig-paths": "4.3.1",
-    "wrangler": "^4.16.0"
+    "wrangler": "^4.16.0",
+    "@playwright/test": "^1.42.1"
   },
   "dependencies": {
     "@angular/localize": "^17.1.3",

--- a/sites/store1/storefront/playwright.config.ts
+++ b/sites/store1/storefront/playwright.config.ts
@@ -1,0 +1,11 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:8080',
+    headless: true,
+  },
+};
+
+export default config;

--- a/sites/store1/storefront/tests/checkout.spec.ts
+++ b/sites/store1/storefront/tests/checkout.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test('can checkout', async ({ page }) => {
+  // Go to home page
+  await page.goto('/');
+
+  // Add first product to cart
+  const addButton = page.locator('button:has-text("Add to cart")').first();
+  await addButton.click();
+
+  // Open cart from header
+  await page.locator('button[aria-label*="items in cart"]').click();
+
+  // Proceed to checkout
+  await page.getByRole('link', { name: 'Checkout' }).click();
+
+  // Fill out shipping form
+  await page.fill('input[name="fullName"]', 'John Doe');
+  await page.fill('input[name="streetLine1"]', '123 Main St');
+  await page.fill('input[name="city"]', 'Metropolis');
+  await page.fill('input[name="postalCode"]', '12345');
+  await page.fill('input[name="phoneNumber"]', '1234567890');
+  const countrySelect = page.locator('select[name="countryCode"]');
+  if (await countrySelect.count()) {
+    await countrySelect.selectOption({ index: 0 });
+  }
+
+  await page.getByRole('button', { name: /proceed to payment/i }).click();
+
+  await expect(page.locator('button:has-text("Pay with")')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright config and basic checkout test to store1 storefront
- add test command and dev dependency

## Testing
- `npm test` *(fails: browser download 403)*

------
https://chatgpt.com/codex/tasks/task_e_68489676ed30832597cf952b9fb4cf41